### PR TITLE
Ignore appletvos-arm64 packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-TARGET := iphone:clang:latest:6.0
-ARCHS = armv7 arm64
-PACKAGE_VERSION = 1.0.1
+TARGET := iphone:clang:14.5:6.0
+ARCHS = armv7 arm64 arm64e
+PACKAGE_VERSION = 1.0.2
 INSTALL_TARGET_PROCESSES = Cydia
 
 include $(THEOS)/makefiles/common.mk

--- a/Tweak.x
+++ b/Tweak.x
@@ -8,7 +8,7 @@
 
 - (BOOL)unfiltered {
     NSString *arch = [self architecture];
-    return [arch isEqualToString:@"iphoneos-arm64"] || [arch isEqualToString:@"iphoneos-arm64e"] ? NO : %orig;
+    return [arch isEqualToString:@"iphoneos-arm64"] || [arch isEqualToString:@"iphoneos-arm64e"] || [arch isEqualToString:@"appletvos-arm64"] ? NO : %orig;
 }
 
 %end


### PR DESCRIPTION
All changes:
- Hide appletvos-arm64 architecture packages
- iPhoneOS 14.5 SDK
- arm64e architecture for building